### PR TITLE
Fix rendering error with FigureResampler

### DIFF
--- a/app_dataagg.py
+++ b/app_dataagg.py
@@ -194,9 +194,12 @@ def server(input: Inputs, output: Outputs, session: Session):
             return ui.tags.div("No se encontró la base de datos.", class_="text-warning")
 
     # render outputs
-    @render_plotly
+    @render.ui
     def plot_plotly():
-        return rv_plotly.get()
+        fig = rv_plotly.get()
+        if fig is None:
+            return ui.div()
+        return ui.HTML(fig.to_html(include_plotlyjs="cdn", full_html=False))
 
     @render_plotly
     def plot_radiacion():

--- a/components/panels.py
+++ b/components/panels.py
@@ -62,7 +62,7 @@ def panel_upload_file():
             ),
             ui.card(
                 ui.card_header("EDA"),
-                output_widget("plot_plotly"),
+                ui.output_ui("plot_plotly"),
                 full_screen=True,
             ),
             col_widths=[3, 2, 7],


### PR DESCRIPTION
## Summary
- handle FigureResampler objects by rendering HTML via `@render.ui`
- update UI to use `output_ui` for the EDA plot

## Testing
- `python -m py_compile app_dataagg.py components/panels.py`

------
https://chatgpt.com/codex/tasks/task_e_686c6a2c1d14832d994eee8389c2f278