### PR TITLE
Enable plotly-resampler widget in Shiny

### DIFF
--- a/app_explorer.py
+++ b/app_explorer.py
@@ -1,5 +1,5 @@
-from shiny import App, ui, render
-from shinywidgets import render_plotly, render_widget
+from shiny import App, ui
+from shinywidgets import render_plotly
 import shinyswatch
 
 from utils.config import name
@@ -45,10 +45,9 @@ app_ui = ui.page_fillable(
 def server(input, output, session):
 
 
-    # @output
-    @render.ui
-    def plot_matplotlib():
-        # return graph_all_matplotlib(input.fechas())
+    @output
+    @render_plotly
+    def plot_resampler():
         return graph_all_plotly_resampler(input.fechas())
 
 

--- a/components/explorador.py
+++ b/components/explorador.py
@@ -1,4 +1,4 @@
-from shiny import ui, reactive, render
+from shiny import ui
 from shinywidgets import output_widget
 
 def panel_explorador():
@@ -14,12 +14,11 @@ def panel_explorador():
             language="es",
             separator="a",
         ),
-        ui.output_ui("plot_matplotlib"),
+        output_widget("plot_resampler"),
     )
 
 
 def panel_estadistica():
     return ui.nav_panel(
         "Estadística",
-        "Aquí irá tu contenido estadístico"
-    )
+        "Aquí irá tu contenido estadístico"    )

--- a/utils/plots.py
+++ b/utils/plots.py
@@ -21,7 +21,7 @@ import matplotlib.pyplot as plt
 
 
 import plotly.graph_objects as go
-from plotly_resampler import FigureResampler, FigureWidgetResampler
+from plotly_resampler import FigureWidgetResampler
 
 
 def graph_all_matplotlib(fechas, alias_dict=None,db_path=db_name):
@@ -110,9 +110,11 @@ def graph_all_plotly_resampler(fechas, db_path=db_name, max_samples=1000):
     noisy_sin = (3 + np.sin(x / 200) + np.random.randn(len(x)) / 10) * x / 1_000
 
     # %%
-    # OPTION 1 - FigureResampler: dynamic aggregation via a Dash web-app
-    fig = FigureResampler(go.Figure())
-    fig.add_trace(go.Scattergl(name='noisy sine', showlegend=True), hf_x=x, hf_y=noisy_sin)
+    # OPTION 1 - FigureWidgetResampler: integrates with widget-based frameworks
+    fig = FigureWidgetResampler(go.Figure())
+    fig.add_trace(
+        go.Scattergl(name="noisy sine", showlegend=True), hf_x=x, hf_y=noisy_sin
+    )
 
     # fig.show_dash(mode='inline')
     return fig


### PR DESCRIPTION
## Summary
- display plotly-resampler output as a widget
- expose plotly-resampler figure in explorer panel
- create FigureWidgetResampler instead of FigureResampler

## Testing
- `PYTHONPATH=.venv/lib/python3.10/site-packages python -m py_compile $(git ls-files '*.py')`
- `PYTHONPATH=.venv/lib/python3.10/site-packages python - <<'PY'
from utils.plots import graph_all_plotly_resampler
fig = graph_all_plotly_resampler(("2024-01-01","2024-01-02"))
print(type(fig))
PY`

------
https://chatgpt.com/codex/tasks/task_e_686ec4c23374832da4e6ac35601b473a