### PR TITLE
Fix plotly resampler usage

### DIFF
--- a/app_explorer.py
+++ b/app_explorer.py
@@ -1,5 +1,5 @@
 from shiny import App, ui
-from shinywidgets import render_plotly
+from shinywidgets import render_widget
 import shinyswatch
 
 from utils.config import name
@@ -46,7 +46,7 @@ def server(input, output, session):
 
 
     @output
-    @render_plotly
+    @render_widget
     def plot_resampler():
         # return graph_all_plotly_resampler(input.fechas())
         return graph_all_plotly_resampler()


### PR DESCRIPTION
## Summary
- enable resampler by registering plotly_resampler in `utils/plots.py`
- build resampler figure with all variables
- expose figure widget correctly in Shiny app

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ede78bbdc832d9aa99e4367f681d2