### PR TITLE
Add download buttons with range filtering

### DIFF
--- a/components/explorador.py
+++ b/components/explorador.py
@@ -4,17 +4,30 @@ from shinywidgets import output_widget
 def panel_explorador():
     return ui.nav_panel(
         "Explorador",
-        # ui.input_date_range(
-        #     "fechas",
-        #     "Fechas:",
-        #     start="2023-11-01",
-        #     end="2025-12-31",
-        #     min="2010-01-01",
-        #     max="2025-12-31",
-        #     language="es",
-        #     separator="a",
-        # ),
+        ui.input_date_range(
+            "fechas",
+            "Fechas:",
+            start="2023-01-01",
+            end="2023-12-31",
+            min="2010-01-01",
+            max="2025-12-31",
+            language="es",
+            separator="a",
+        ),
         output_widget("plot_resampler"),
+        ui.div(
+            ui.download_button(
+                "dl_parquet",
+                "Descargar Parquet",
+                class_="btn btn-outline-primary me-2",
+            ),
+            ui.download_button(
+                "dl_csv",
+                "Descargar CSV",
+                class_="btn btn-outline-primary",
+            ),
+            class_="mt-3",
+        ),
     )
 
 

--- a/utils/plots.py
+++ b/utils/plots.py
@@ -101,16 +101,35 @@ def graph_all_matplotlib(fechas, alias_dict=None,db_path=db_name):
 
 
 
-def graph_all_plotly_resampler(db_path=db_name):
-    """Return a Plotly figure with dynamic resampling enabled."""
+def graph_all_plotly_resampler(fechas=None, db_path=db_name):
+    """Return a Plotly figure with dynamic resampling enabled.
+
+    Parameters
+    ----------
+    fechas : tuple[str, str] | None
+        Optional start/end dates in ISO format ``YYYY-MM-DD``. When provided,
+        only records within this interval are loaded from the database.
+    db_path : str
+        Path to the DuckDB database.
+    """
 
     # 1) Load data and pivot into wide format
     con = duckdb.connect(db_path)
-    q = """
-    SELECT *
-      FROM lecturas
-     ORDER BY date
-    """
+
+    if fechas is None:
+        q = """
+        SELECT *
+          FROM lecturas
+         ORDER BY date
+        """
+    else:
+        q = f"""
+        SELECT *
+          FROM lecturas
+         WHERE date >= TIMESTAMP '{fechas[0]}'
+           AND date <= TIMESTAMP '{fechas[1]}'
+         ORDER BY date
+        """
     df = con.execute(q).fetchdf()
     con.close()
     df = df.pivot(index="date", columns="variable", values="value")


### PR DESCRIPTION
## Summary
- let `graph_all_plotly_resampler` accept a date range
- add a date range input and download buttons to `panel_explorador`
- implement download handlers in `app_explorer` for Parquet and CSV exports

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f0b3f4a24832d96b6f603af1daf86