### PR TITLE
Switch explorer to Matplotlib plots

### DIFF
--- a/app_explorer.py
+++ b/app_explorer.py
@@ -1,5 +1,4 @@
 from shiny import App, ui, render
-from shinywidgets import render_widget
 import shinyswatch
 import duckdb
 import io
@@ -16,7 +15,7 @@ from components.panels import (
 )
 
 # from utils.data_processing import load_esolmet_data
-from utils.plots import graph_all_plotly_resampler, plot_explorer_matplotlib
+from utils.plots import plot_explorer_matplotlib
 
 
 app_ui = ui.page_fillable(
@@ -48,7 +47,7 @@ def server(input, output, session):
 
 
     @output
-    @render_widget
+    @render.plot
     def plot_explorer():
         fechas = input.fechas()
         if fechas is not None:

--- a/components/explorador.py
+++ b/components/explorador.py
@@ -1,5 +1,4 @@
 from shiny import ui
-from shinywidgets import output_widget
 
 def panel_explorador():
     return ui.nav_panel(
@@ -14,7 +13,7 @@ def panel_explorador():
             language="es",
             separator="a",
         ),
-        output_widget("plot_explorer"),
+        ui.output_plot("plot_explorer"),
         ui.div(
             ui.download_button(
                 "dl_parquet",


### PR DESCRIPTION
## Summary
- use `plot_explorer_matplotlib` instead of the old Plotly resampler
- display the explorer with `render.plot` and `ui.output_plot`

## Testing
- `python -m py_compile app_explorer.py components/explorador.py utils/plots.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f11c63158832dabf22e352caa47f0