### PR TITLE
Speed up seasonal wind roses

### DIFF
--- a/components/panels.py
+++ b/components/panels.py
@@ -101,7 +101,7 @@ def panel_eolica():
                     "Selecciona rango de años:",
                     min=min_year,
                     max=max_year,
-                    value=(min_year, max_year),
+                    value=(max_year, max_year),
                     step=1
                 ),
                 ui.input_task_button(

--- a/components/wind_power_server.py
+++ b/components/wind_power_server.py
@@ -114,7 +114,13 @@ def wind_power_server(input, output, session):
             return None
         with reactive.isolate():
             start_year, end_year = input.season_year_range()
-        df = esolmet.loc[f"{start_year}-01-01": f"{end_year}-12-31"]
+        max_year = esolmet.index.year.max()
+        if start_year == end_year == max_year:
+            end_date = esolmet.index.max()
+            start_date = end_date - pd.DateOffset(years=1) + pd.Timedelta(days=1)
+            df = esolmet.loc[start_date:end_date]
+        else:
+            df = esolmet.loc[f"{start_year}-01-01": f"{end_year}-12-31"]
         return create_seasonal_wind_roses_by_speed_plotly(df)
 
     @render_widget


### PR DESCRIPTION
## Summary
- default seasonal wind rose slider to most recent year
- trim data to one year when requesting seasonal roses

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873e378fc44832da155882d48b55da3