### PR TITLE
Speed up wind roses

### DIFF
--- a/components/panels.py
+++ b/components/panels.py
@@ -42,10 +42,14 @@ def panel_eolica():
     df = df_lect.pivot(index="date", columns="variable", values="value")
     df.index = pd.to_datetime(df.index)
     df = df.sort_index()
-    min_year = df.index.year.min()# Calculamos maximos i minimos 
+    min_year = df.index.year.min()# Calculamos maximos i minimos
     max_year = df.index.year.max()
-    min_date = str(df.index.min().date())
-    max_date = str(df.index.max().date())
+    min_date_dt = df.index.min()
+    max_date_dt = df.index.max()
+    min_date = str(min_date_dt.date())
+    max_date = str(max_date_dt.date())
+    start_last_year_dt = max(max_date_dt - pd.DateOffset(years=1) + pd.Timedelta(days=1), min_date_dt)
+    start_last_year = str(start_last_year_dt.date())
     return ui.nav_panel(
         "Eólica",
         ui.navset_tab(
@@ -57,10 +61,10 @@ def panel_eolica():
                 ui.input_date_range(
                     "wind_date_range",
                     "Selecciona periodo:",
-                    start=min_date,  # fecha de inicio por defecto
-                    end=max_date,    # fecha de fin por defecto
-                    min=min_date,    # límite mínimo seleccionable
-                    max=max_date     # límite máximo seleccionable
+                    start=start_last_year,  # fecha de inicio por defecto
+                    end=max_date,           # fecha de fin por defecto
+                    min=min_date,           # límite mínimo seleccionable
+                    max=max_date            # límite máximo seleccionable
                 ),
                 ui.input_task_button(
                     "run_wind_annual",
@@ -73,7 +77,7 @@ def panel_eolica():
                 ui.input_date_range(
                     "wind_period_range",
                     "Selecciona periodo:",
-                    start=min_date, end=max_date,
+                    start=start_last_year, end=max_date,
                     min=min_date,   max=max_date
                 ),
                 ui.input_task_button(
@@ -96,13 +100,13 @@ def panel_eolica():
 
                 # Rosa estacional
                 ui.h3("Rosa de viento promedio estacional"),
-                ui.input_slider(
-                    "season_year_range",
-                    "Selecciona rango de años:",
-                    min=min_year,
-                    max=max_year,
-                    value=(min_year, max_year),
-                    step=1
+                ui.input_date_range(
+                    "season_date_range",
+                    "Selecciona periodo:",
+                    start=start_last_year,
+                    end=max_date,
+                    min=min_date,
+                    max=max_date,
                 ),
                 ui.input_task_button(
                     "run_wind_seasonal",
@@ -125,8 +129,10 @@ def panel_eolica():
                 ui.input_date_range(
                     "heatmap_speed_range",
                     "Selecciona periodo:",
-                    start=min_date, end=max_date,
-                    min=min_date,   max=max_date
+                    start=start_last_year,
+                    end=max_date,
+                    min=min_date,
+                    max=max_date,
                 ),
                 ui.row(
                     ui.column(

--- a/components/wind_power_server.py
+++ b/components/wind_power_server.py
@@ -113,8 +113,16 @@ def wind_power_server(input, output, session):
         if n_clicks is None or n_clicks == 0:
             return None
         with reactive.isolate():
-            start_year, end_year = input.season_year_range()
-        df = esolmet.loc[f"{start_year}-01-01": f"{end_year}-12-31"]
+            start_date_str, end_date_str = input.season_date_range()
+        max_date = esolmet.index.max()
+        min_date = esolmet.index.min()
+        start_last_year = max(max_date - pd.DateOffset(years=1) + pd.Timedelta(days=1), min_date)
+        start_date = pd.to_datetime(start_date_str)
+        end_date = pd.to_datetime(end_date_str)
+        if start_date == start_last_year and end_date == max_date:
+            df = esolmet.loc[start_last_year:end_date]
+        else:
+            df = esolmet.loc[start_date:end_date]
         return create_seasonal_wind_roses_by_speed_plotly(df)
 
     @render_widget


### PR DESCRIPTION
## Summary
- default wind rose date ranges to the most recent year
- limit seasonal wind roses to the last year when the latest year is selected
- switch seasonal wind rose UI to use a date range instead of a year slider
- default heatmap date range to the last year

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6873e378fc44832da155882d48b55da3