### PR TITLE
Improve explorer date selection

### DIFF
--- a/components/explorador.py
+++ b/components/explorador.py
@@ -1,15 +1,31 @@
 from shiny import ui
+import duckdb
+import pandas as pd
+from utils.config import db_name
 
 def panel_explorador():
+    conn = duckdb.connect(database=db_name, read_only=True)
+    min_date, max_date = conn.execute(
+        "SELECT min(date), max(date) FROM lecturas"
+    ).fetchone()
+    conn.close()
+
+    min_date_dt = pd.to_datetime(min_date)
+    max_date_dt = pd.to_datetime(max_date)
+    start_last_year_dt = max(
+        max_date_dt - pd.DateOffset(years=1) + pd.Timedelta(days=1),
+        min_date_dt,
+    )
+
     return ui.nav_panel(
         "Explorador con pull",
         ui.input_date_range(
             "fechas",
             "Fechas:",
-            start="2023-01-01",
-            end="2025-12-31",
-            min="2010-01-01",
-            max="2030-12-31",
+            start=str(start_last_year_dt.date()),
+            end=str(max_date_dt.date()),
+            min=str(min_date_dt.date()),
+            max=str(max_date_dt.date()),
             language="es",
             separator="a",
         ),
@@ -18,12 +34,10 @@ def panel_explorador():
             ui.download_button(
                 "dl_parquet",
                 "Download parquet",
-                # class_="btn btn-outline-primary",
             ),
             ui.download_button(
                 "dl_csv",
                 "Download csv",
-                # class_="btn btn-outline-primary",
             ),
             class_="d-flex justify-content-center gap-1 "
         ),

--- a/components/explorer_server.py
+++ b/components/explorer_server.py
@@ -2,6 +2,8 @@
 from shiny import App, ui, render
 import shinyswatch
 import duckdb
+import io
+from utils.config import db_name
 from utils.plots import plot_explorer_matplotlib
 
 


### PR DESCRIPTION
## Summary
- make data range for explorer dynamic
- load last year by default
- fix missing imports in explorer server

## Testing
- `pytest -q`
- `python -m py_compile components/explorador.py components/explorer_server.py`


------
https://chatgpt.com/codex/tasks/task_e_6873f2830310832d96bdc1ac89584344