### PR TITLE
Fix mean year plot

### DIFF
--- a/utils/plots.py
+++ b/utils/plots.py
@@ -726,15 +726,16 @@ def plot_mean_year_plotly():
 
 
     # 1) Cálculo diario (igual que antes)
-    daily = df['tdb_mean'].resample('D').agg(['min','max','mean'])
+    daily = df['tdb_mean'].resample('D').agg(['min', 'max', 'mean'])
     daily['range'] = daily['max'] - daily['min']
+    daily = daily.reset_index().rename(columns={"index": "date"})
 
     # 2) Figura única
     fig = go.Figure()
 
     # Barra “range” (min→max)
     fig.add_trace(go.Bar(
-        x=daily.index,
+        x=daily["date"],
         y=daily['range'],
         base=daily['min'],
         marker=dict(color='rgba(255,0,0,0.2)'),
@@ -744,7 +745,7 @@ def plot_mean_year_plotly():
 
     # Línea de promedio diario
     fig.add_trace(go.Scatter(
-        x=daily.index,
+        x=daily["date"],
         y=daily['mean'],
         mode='lines',
         line=dict(color='red', width=1),


### PR DESCRIPTION
## Summary
- reset date index when plotting mean year series
- plot using the date column

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687673ba527c832db28b258800c622bf