### PR TITLE
Add Descarga tab with download controls

### DIFF
--- a/app_explorer.py
+++ b/app_explorer.py
@@ -5,7 +5,7 @@ import io
 
 from utils.config import name, db_name
 
-from components.explorador import panel_explorador, panel_estadistica
+from components.explorador import panel_descarga, panel_explorador, panel_estadistica
 from components.panels import (
     panel_documentacion,
     panel_trayectoriasolar,
@@ -29,8 +29,9 @@ app_ui = ui.page_fillable(
         ui.nav_panel(
             name,
             ui.navset_card_tab(
-                panel_explorador(), 
-                panel_estadistica(), 
+                panel_descarga(),
+                panel_explorador(),
+                panel_estadistica(),
                 id="climalab_subtabs"
             ),
         ),

--- a/components/explorador.py
+++ b/components/explorador.py
@@ -41,6 +41,42 @@ def panel_explorador():
         info_rango,
         ui.hr(),
         ui.output_plot("plot_explorer"),
+    )
+
+
+def panel_descarga():
+    conn = duckdb.connect(database=db_name, read_only=True)
+    min_date, max_date = conn.execute(
+        "SELECT min(date), max(date) FROM lecturas"
+    ).fetchone()
+    conn.close()
+
+    min_date_dt = pd.to_datetime(min_date)
+    max_date_dt = pd.to_datetime(max_date)
+    start_last_year_dt = max(
+        max_date_dt - pd.DateOffset(days=120) + pd.Timedelta(days=1),
+        min_date_dt,
+    )
+
+    info_rango = ui.h6(
+        f"Datos disponibles de {min_date_dt.date()} al {max_date_dt.date()}",
+        class_="text-muted mb-2 text-center",
+    )
+    return ui.nav_panel(
+        "Descarga",
+        ui.input_date_range(
+            "fechas_descarga",
+            "Fechas:",
+            start=str(start_last_year_dt.date()),
+            end=str(max_date_dt.date()),
+            min=str(min_date_dt.date()),
+            max=str(max_date_dt.date()),
+            language="es",
+            separator="a",
+        ),
+        ui.hr(),
+        info_rango,
+        ui.hr(),
         ui.div(
             ui.download_button(
                 "dl_parquet",
@@ -50,7 +86,7 @@ def panel_explorador():
                 "dl_csv",
                 "Download csv",
             ),
-            class_="d-flex justify-content-center gap-1 "
+            class_="d-flex justify-content-center gap-1",
         ),
     )
 

--- a/components/explorer_server.py
+++ b/components/explorer_server.py
@@ -35,10 +35,10 @@ def explorer_server(input, output, session):
     @output
     @render.download(filename="ClimaLab.parquet", media_type="application/x-parquet")
     def dl_parquet():
-        fechas = input.fechas()
+        fechas = input.fechas_descarga()
         if fechas is None:
             return
-        df = _query_df(fechas) 
+        df = _query_df(fechas)
         with io.BytesIO() as buf:
             df.to_parquet(buf, index=True, engine="pyarrow")
             buf.seek(0)
@@ -47,7 +47,7 @@ def explorer_server(input, output, session):
     @output
     @render.download(filename="ClimaLab.csv", media_type="text/csv")
     def dl_csv():
-        fechas = input.fechas()
+        fechas = input.fechas_descarga()
         if fechas is None:
             return
         df = _query_df(fechas)


### PR DESCRIPTION
## Summary
- add `panel_descarga` with date range and download buttons
- update explorer server to use new range selector for downloads
- place `panel_descarga` before explorer and statistics in the UI
- drop download buttons from Explorer tab

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878459a6350832dbdaf9ef1ce52dfc8