### PR TITLE
Update navigation labels and download filenames

### DIFF
--- a/components/explorador.py
+++ b/components/explorador.py
@@ -26,7 +26,7 @@ def panel_explorador():
         class_="text-muted mb-2 text-center"   # opcional: gris y peque-ño margen inferior
     )
     return ui.nav_panel(
-        "Explorador",
+        "Explorar",
         ui.input_date_range(
             "fechas",
             "Fechas:",
@@ -63,7 +63,7 @@ def panel_descarga():
         class_="text-muted mb-2 text-center",
     )
     return ui.nav_panel(
-        "Descarga",
+        "Descargar",
         ui.input_date_range(
             "fechas_descarga",
             "Fechas:",

--- a/components/explorer_server.py
+++ b/components/explorer_server.py
@@ -33,7 +33,10 @@ def explorer_server(input, output, session):
         return df
 
     @output
-    @render.download(filename="ClimaLab.parquet", media_type="application/x-parquet")
+    @render.download(
+        filename=lambda: f"ClimaLab_{input.fechas_descarga()[0]}_{input.fechas_descarga()[1]}.parquet",
+        media_type="application/x-parquet",
+    )
     def dl_parquet():
         fechas = input.fechas_descarga()
         if fechas is None:
@@ -45,7 +48,10 @@ def explorer_server(input, output, session):
             yield buf.getvalue()
 
     @output
-    @render.download(filename="ClimaLab.csv", media_type="text/csv")
+    @render.download(
+        filename=lambda: f"ClimaLab_{input.fechas_descarga()[0]}_{input.fechas_descarga()[1]}.csv",
+        media_type="text/csv",
+    )
     def dl_csv():
         fechas = input.fechas_descarga()
         if fechas is None:


### PR DESCRIPTION
## Summary
- rename navbar labels "Explorador" -> "Explorar" and "Descarga" -> "Descargar"
- append date range to Parquet and CSV download filenames

## Testing
- `pytest -q test.py` *(fails: pandas missing, install blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68791e0e8ef0832d87c8ecdd29354174